### PR TITLE
Add docker entrypoint script

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+if [ -n "${LOCAL_UID}" ]; then
+    LOCAL_GID=${LOCAL_GID:-${LOCAL_UID}}
+
+    groupadd -o --gid=${LOCAL_GID} opx-dev
+    useradd -o --uid=${LOCAL_UID} --gid=${LOCAL_GID} -s /bin/bash opx-dev
+    echo '%opx-dev ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+    exec gosu opx-dev "$@"
+fi
+
+exec "$@"

--- a/scripts/opx_build_Dockerfile
+++ b/scripts/opx_build_Dockerfile
@@ -1,7 +1,27 @@
 FROM debian:jessie
 RUN apt-get update 
 RUN apt-get upgrade -y
-RUN apt-get install -y git-buildpackage dh-autoreconf dh-systemd vim
+RUN apt-get install -y git-buildpackage dh-autoreconf dh-systemd vim wget
+
+# Install gosu utility for use in entrypoint script
+#
+# Since gosu is not available as a package in jessie (it is in stretch),
+# we need to fetch the binary from github. If the container is switched
+# to stretch (even if OPX continues to target jessie), we can use the
+# package instead.
+#
+ENV GOSU_VERSION 1.9
+RUN set -x \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true
+
+COPY entrypoint.sh /
 COPY pbuilderrc /etc/pbuilderrc
 COPY D05update-deps /var/cache/pbuilder/hook.d/
 RUN touch /var/cache/pbuilder/result/Packages

--- a/scripts/opx_setup
+++ b/scripts/opx_setup
@@ -48,7 +48,7 @@ if [ "${ID}b" = b ] ; then
 
   rm -f ${CIDFILE}
   docker run --cidfile ${CIDFILE} --privileged -e DIST=jessie docker-opx:base sh -c 'git-pbuilder create; git-pbuilder update; echo "apt-get install -y python-pip; pip install pyang; ln -s /usr/local/bin/pyang /usr/bin" | git-pbuilder login --save-after-login'
-  docker commit --change 'CMD ["bash"]' `cat ${CIDFILE}` docker-opx:latest
+  docker commit --change 'CMD ["bash"]' --change 'ENTRYPOINT ["/entrypoint.sh"]' `cat ${CIDFILE}` docker-opx:latest
   docker rm `cat ${CIDFILE}`
 
   # cleanup


### PR DESCRIPTION
Adds docker entrypoint script which creates opx-dev user and group
entries matching the uid and gid of the invoking user. The uid and
gid are passed from the host to the container through environment
variables LOCAL_UID and LOCAL_GID.

This provides a convienent way to have the container use the same
uid and gid for mapped filesystem access.