### PR TITLE
Generalize opx_run

### DIFF
--- a/scripts/opx_run
+++ b/scripts/opx_run
@@ -15,4 +15,4 @@
 # permissions and limitations under the License.
 #
 
-docker run --rm --privileged -i -t -e LOCAL_UID=$(id -u ${USER}) -e LOCAL_GID=$(id -g ${USER}) -v ${PWD}:/mnt docker-opx:latest
+docker run --rm --privileged -i -t -e LOCAL_UID=$(id -u ${USER}) -e LOCAL_GID=$(id -g ${USER}) -v ${PWD}:/mnt docker-opx:latest "$@"


### PR DESCRIPTION
Use "$@" to allow user to specify an (optional) command to run.  If
no command is provided, an interactive shell is started.