### PR TITLE
Use one Docker image for both pbuilder roots

### DIFF
--- a/Dockerfile-jessie
+++ b/Dockerfile-jessie
@@ -5,7 +5,6 @@ ENV DIST jessie
 
 RUN apt-get -qq update && apt-get -qq upgrade -y && apt-get -qq install -y \
     build-essential \
-    cowbuilder \
     curl \
     debian-archive-keyring \
     debootstrap \
@@ -13,7 +12,6 @@ RUN apt-get -qq update && apt-get -qq upgrade -y && apt-get -qq install -y \
     dh-systemd \
     fakechroot \
     fakeroot \
-    git-buildpackage \
     lsb-release \
     python-apt \
     python-jinja2 \
@@ -22,7 +20,7 @@ RUN apt-get -qq update && apt-get -qq upgrade -y && apt-get -qq install -y \
     python-requests \
     vim \
     wget \
- && apt-get -t jessie-backports install -y gosu \
+ && apt-get -t jessie-backports install -y cowbuilder git-buildpackage gosu \
  && apt-get -qq autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Pyang not available as Debian package
@@ -32,8 +30,7 @@ RUN pip2 install pyang requests-file \
 # Get OPX and other Debian GPG keys
 RUN gpg --import /usr/share/keyrings/debian-archive-keyring.gpg \
  && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key AD5073F1 \
- && gpg --export AD5073F1 >/usr/share/keyrings/opx-archive-keyring.gpg \
- && apt-key add /usr/share/keyrings/opx-archive-keyring.gpg
+ && gpg --export AD5073F1 >/etc/apt/trusted.gpg.d/opx-archive-keyring.gpg
 
 # Add OPX package sources
 RUN mkdir -p /etc/apt/sources.list.d/ \
@@ -47,9 +44,6 @@ RUN mkdir -p /home/opx && chmod -R 777 /home/opx \
  && echo 'opx ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers \
  && echo '%opx ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers \
  && echo 'Defaults env_keep += "OPX_RELEASE DIST ARCH"' >>/etc/sudoers
-
-# Stops pbuilder create from failing
-RUN mkdir -p /mnt/pool/${DIST}-amd64 && touch /mnt/pool/${DIST}-amd64/Packages
 
 COPY assets/profile /etc/profile.d/opx.sh
 COPY assets/entrypoint.sh /

--- a/Dockerfile-stretch
+++ b/Dockerfile-stretch
@@ -48,9 +48,6 @@ RUN mkdir -p /home/opx && chmod -R 777 /home/opx \
  && echo '%opx ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers \
  && echo 'Defaults env_keep += "OPX_RELEASE DIST ARCH"' >>/etc/sudoers
 
-# Stops pbuilder create from failing
-RUN mkdir -p /mnt/pool/${DIST}-amd64 && touch /mnt/pool/${DIST}-amd64/Packages
-
 COPY assets/profile /etc/profile.d/opx.sh
 COPY assets/entrypoint.sh /
 COPY assets/hook.d /var/cache/pbuilder/hook.d

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OPX Build
 
-This repository contains build information for OpenSwitch OPX.
+*Build environment and scripts for OpenSwitch.*
 
 If you would like to download binaries instead, see
 [Install OPX on Dell EMC ON Series platforms][install-docs].

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you would like to download binaries instead, see
 
 ```bash
 # get source code
-repo init -u git://git.openswitch.net/opx/opx-manifest && repo sync
+repo init -u https://github.com/open-switch/opx-manifest && repo sync
 
 # build all open-source packages
 opx-build/scripts/opx_run opx_build all
@@ -30,7 +30,7 @@ opx-build/scripts/opx_run opx_rel_pkgasm.py --dist unstable \
 ### Get source code
 
 ```bash
-repo init -u git://git.openswitch.net/opx/opx-manifest && repo sync
+repo init -u https://github.com/open-switch/opx-manifest && repo sync
 ```
 
 The `repo` commands download all of the source files that are necessary to

--- a/assets/pbuilder_create.sh
+++ b/assets/pbuilder_create.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -eu
 
+mkdir -p "/mnt/pool/${DIST}-${ARCH}" && touch "/mnt/pool/${DIST}-${ARCH}/Packages"
+
 git-pbuilder create
 git-pbuilder update
 cat <<PBUILDER | git-pbuilder login --save-after-login

--- a/assets/pbuilderrc
+++ b/assets/pbuilderrc
@@ -8,7 +8,7 @@
 : ${DIST:="$(lsb_release --short --codename)"}
 : ${ARCH:="$(dpkg --print-architecture)"}
 
-APTKEYRINGS=( /usr/share/keyrings/opx-archive-keyring.gpg )
+APTKEYRINGS=( /etc/apt/trusted.gpg.d/opx-archive-keyring.gpg )
 BINDMOUNTS="/mnt/pool/${DIST}-${ARCH}"
 HOOKDIR=/var/cache/pbuilder/hook.d
 MIRRORSITE=http://deb.debian.org/debian

--- a/scripts/opx_run
+++ b/scripts/opx_run
@@ -12,7 +12,7 @@ export ARCH="${ARCH:-amd64}"
 # docker image name
 IMAGE="opxhub/build"
 # docker image tag
-VERSION="${VERSION:-$DIST}"
+VERSION="${VERSION:-latest}"
 
 interactive="-i"
 if [ -t 1 ]; then


### PR DESCRIPTION
* Install git-buildpackage from jessie-backports to build stretch root
* Put OPX gpg key in /etc/apt/trusted.gpg.d/ to skip apt-key add step
* Touch local Packages file in pbuilder create script

Signed-off-by: Tyler Heucke <tyler.heucke@dell.com>