### PR TITLE
Updating Jinja2 to fix security vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ opx-build/scripts/opx_run opx_rel_pkgasm.py --dist stable \
 ```
 
 The default Docker image builds against the unstable OPX distribution. When
-other distributions are requested, pbuidler chroots are created on the fly.
+other distributions are requested, pbuilder chroots are created on the fly.
 These chroots are lost when the container is removed, but only take 7.5sec to
 create.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.20.0
-Jinja2==2.9.6
+Jinja2>=2.10.1
 lxml==3.8.0
 requests_file==1.4.2


### PR DESCRIPTION
Signed-off-by: Mithil Patel <Mithil_patel@dell.com>

This is to fix : https://nvd.nist.gov/vuln/detail/CVE-2019-10906 as reported by GitHub.